### PR TITLE
Look for the transpile property in package.json before .dev_properties.json

### DIFF
--- a/util/properties.js
+++ b/util/properties.js
@@ -29,15 +29,13 @@ const getAppType = () => {
 };
 
 const getTranspile = () => {
-  const { transpile } = require(DEV_PROPERTIES_PATH);
-  if (typeof transpile === 'boolean') {
-    return transpile;
+  const { sitevision_scripts_properties } = require(PACKAGE_JSON_PATH);
+  if (sitevision_scripts_properties && typeof sitevision_scripts_properties.transpile === 'boolean') {
+    return sitevision_scripts_properties.transpile;
   }
 
-  const { sitevision_scripts_properties } = require(PACKAGE_JSON_PATH);
-  return (
-    sitevision_scripts_properties && sitevision_scripts_properties.transpile
-  );
+  const { transpile } = require(DEV_PROPERTIES_PATH);
+  return transpile;
 };
 
 module.exports = {


### PR DESCRIPTION
This load order change resolves an issue in the build script where it would crash when .dev_properties.json was missing. Looking at the history of this repo, this seems to be the more favourable way to do it anyway?

This was discovered in our (Euro Accident’s) continuous deployment pipeline, which builds, signs, and deploys all apps in our repository on `git push` (why this deployment flow? Firewalls). Since dev_properties is in our gitignore, our aggregated build script, which runs `npm run build` in each app’s folder as a child process, would fail with the following stacktrace:
```node
internal/modules/cjs/loader.js:883
  throw err;
  ^

Error: Cannot find module './Webapps/<app>/.dev_properties.json'
Require stack:
- ./Webapps/<app>/node_modules/@sitevision/sitevision-scripts/util/properties.js
- ./Webapps/<app>/node_modules/@sitevision/sitevision-scripts/bin/sitevision-scripts.js
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:880:15)
    at Function.Module._load (internal/modules/cjs/loader.js:725:27)
    at Module.require (internal/modules/cjs/loader.js:952:19)
    at require (internal/modules/cjs/helpers.js:88:18)
    at Object.getTranspile (./Webapps/<app>/node_modules/@sitevision/sitevision-scripts/util/properties.js:32:25)
    at Object.<anonymous> (./Webapps/<app>/node_modules/@sitevision/sitevision-scripts/bin/sitevision-scripts.js:64:20)
    at Module._compile (internal/modules/cjs/loader.js:1063:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1092:10)
    at Module.load (internal/modules/cjs/loader.js:928:32)
    at Function.Module._load (internal/modules/cjs/loader.js:769:14) {
  code: 'MODULE_NOT_FOUND',
  requireStack: [
    './Webapps/<app>/node_modules/@sitevision/sitevision-scripts/util/properties.js',
    './Webapps/<app>/node_modules/@sitevision/sitevision-scripts/bin/sitevision-scripts.js'
  ]
}
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! <app>@<version> build: `sitevision-scripts build`
npm ERR! Exit status 1
```